### PR TITLE
EnvironmentごとにEntityの位置や回転を保存する

### DIFF
--- a/Camp/Camp/CraftGesture.swift
+++ b/Camp/Camp/CraftGesture.swift
@@ -10,7 +10,7 @@ struct CraftGesture: ViewModifier {
     @State var initialScale: SIMD3<Float> = .one
     @State var initialOrientation:simd_quatf = simd_quatf(vector: .zero)
 
-    var onGestureEnded: (Craft) -> Void
+    var onGestureEnded: (String, SIMD3<Float>, SIMD3<Float>, SIMD4<Float>) -> Void
     
     func body(content: Content) -> some View {
         content
@@ -35,7 +35,7 @@ struct CraftGesture: ViewModifier {
             }
             .onEnded { value in
                 endGesture()
-                onGestureEnded(.init(entity: value.entity))
+                onGestureEnded(with: value.entity)
             }
     }
     
@@ -53,7 +53,7 @@ struct CraftGesture: ViewModifier {
             }
             .onEnded { value in
                 endGesture()
-                onGestureEnded(.init(entity: value.entity))
+                onGestureEnded(with: value.entity)
             }
     }
     
@@ -79,7 +79,7 @@ struct CraftGesture: ViewModifier {
             }
             .onEnded { value in
                 endGesture()
-                onGestureEnded(.init(entity: value.entity))
+                onGestureEnded(with: value.entity)
             }
     }
     
@@ -104,10 +104,17 @@ struct CraftGesture: ViewModifier {
         initialScale = .one
         initialOrientation = simd_quatf(vector: .zero)
     }
+    
+    private func onGestureEnded(with entity: Entity) {
+        onGestureEnded(entity.name,
+                       entity.transform.translation,
+                       entity.scale,
+                       entity.orientation.vector)
+    }
 }
 
 extension View {
-    func craftGesture(onGestureEnded: @escaping (Craft) -> Void) -> some View {
+    func craftGesture(onGestureEnded: @escaping (String, SIMD3<Float>, SIMD3<Float>, SIMD4<Float>) -> Void) -> some View {
         modifier(CraftGesture(onGestureEnded: onGestureEnded))
     }
 }

--- a/Camp/Camp/Data/Craft.swift
+++ b/Camp/Camp/Data/Craft.swift
@@ -3,7 +3,9 @@ import RealityKit
 
 @Model
 class Craft {
-    @Attribute(.unique) var name: String
+    @Attribute(.unique) var id: String
+    var name: String
+    var environment: String
     
     // Due to the following issue, it seems that we cannot store a single SIMD3<Float> with SwiftData currently.
     // https://developer.apple.com/forums/thread/763634
@@ -11,18 +13,13 @@ class Craft {
     var scale: CraftScale
     var orientation: CraftOrientation
     
-    init(name: String, translation: CraftTranslation, scale: CraftScale, orientation: CraftOrientation) {
+    init(name: String, environment: String, translation: SIMD3<Float>, scale: SIMD3<Float>, orientation: SIMD4<Float>) {
+        self.id = name + "_" + environment
         self.name = name
-        self.translation = translation
-        self.scale = scale
-        self.orientation = orientation
-    }
-    
-    init(entity: Entity) {
-        self.name = entity.name
-        self.translation = .init(entity.transform.translation)
-        self.scale = .init(entity.scale)
-        self.orientation = .init(entity.orientation.vector)
+        self.environment = environment
+        self.translation = .init(translation)
+        self.scale = .init(scale)
+        self.orientation = .init(orientation)
     }
 }
 

--- a/Camp/Camp/View/ImmersiveView.swift
+++ b/Camp/Camp/View/ImmersiveView.swift
@@ -34,8 +34,12 @@ struct ImmersiveView: View {
         .onDisappear {
             appModel.changeImmersiveSpaceState(.closed)
         }
-        .craftGesture { craft in
-            saveCraft(craft)
+        .craftGesture { name, translation, scale, orientation in
+            saveCraft(.init(name: name,
+                            environment: appModel.campEnvironment.rawValue,
+                            translation: translation,
+                            scale: scale,
+                            orientation: orientation))
         }
     }
     

--- a/Camp/Camp/ViewModel/ImmersiveViewModel.swift
+++ b/Camp/Camp/ViewModel/ImmersiveViewModel.swift
@@ -16,21 +16,33 @@ final class ImmersiveViewModel {
         scene.scale *= sceneScale
         rootEntity?.addChild(scene)
         
-        for craft in crafts {
-            if let entity = scene.findEntity(named: craft.name) {
-                var position = craft.translation.simd3
-                position *= sceneScale
-                
-                entity.setPosition(position, relativeTo: nil)
-//                    entity.setScale(craft.scale.simd3, relativeTo: nil)
-                entity.setOrientation(.init(vector: craft.orientation.simd4), relativeTo: nil)
-            }
-        }
+        // Restore craft positions and rotations
+        restoreCrafts(crafts, scene: scene, environment: environment)
 
         if let skybox = Entity.createSkybox(environment: environment) {
             rootEntity?.addChild(skybox)
         }
 
+        // Setup particles
+        setupParticles(environment: environment)
+
+        let light = Entity.createDirectionalLight()
+        rootEntity?.addChild(light)
+    }
+    
+    private func restoreCrafts(_ crafts: [Craft], scene: Entity, environment: CampEnvironment) {
+        for craft in crafts {
+            if let entity = scene.findEntity(named: craft.name), craft.environment == environment.rawValue {
+                var position = craft.translation.simd3
+                position *= sceneScale
+                
+                entity.setPosition(position, relativeTo: nil)
+                entity.setOrientation(.init(vector: craft.orientation.simd4), relativeTo: nil)
+            }
+        }
+    }
+    
+    private func setupParticles(environment: CampEnvironment) {
         switch environment {
         case .spring:
             Task {
@@ -43,8 +55,5 @@ final class ImmersiveViewModel {
             // 何もしない
             break
         }
-
-        let light = Entity.createDirectionalLight()
-        rootEntity?.addChild(light)
     }
 }


### PR DESCRIPTION
現状ではEnvironment関係なく共通でEntityの位置や回転を保存しているが、Environmentごとに存在する・存在しないアイテムがあり、異なる配置が望ましいこともあるので、EnvironmentごとにCraft情報を保存・復元するようにしました